### PR TITLE
Update warnings, ignored files, and information for Pylint task

### DIFF
--- a/cog/tasks/templates/pylint.html
+++ b/cog/tasks/templates/pylint.html
@@ -25,5 +25,10 @@
 
     {pylint_info}
 
+    <p><br></p>
+    <hr/>
+
+    <p>Pylint version used to produce this test: {pylint_version}</p>
+
   </body>
 </html>


### PR DESCRIPTION
A few small changes to the Pylint task:
- Add two new warnings to exclude (only applicable to Python3).
- Remove couchdb from ignore list.
- Save the version and full pylint command to the document.

@BenLand100 whenever you get a chance to look at this and merge that would be great. Thanks!