### PR TITLE
Update pylint checks

### DIFF
--- a/cog/tasks/pylint.py
+++ b/cog/tasks/pylint.py
@@ -15,12 +15,13 @@ class PyLint(cog.task.Task):
 
         # Messages/warnings/errors to enable and disable.
         self.messages_enable = ['all']
-        self.messages_disable = ['I0011', 'I0020', 'R0902',
+        self.messages_disable = ['I0011', 'I0020', 'R0902', 'W1514', 'R1732',
                                  'R0911', 'R0912', 'R0913', 'R0914', 'R0915',
-                                 'R1702', 'R0801', 'R1705', 'R0201', 'R0205',
+                                 'R1702', 'R0801', 'R1705', 'C0209', 'R0205',
                                  'C0103', 'C0301', 'C0302', 'C0413', 'C0114',
                                  'W0122', 'W0406', 'W0621', 'W0703', 'W0707',
-                                 'W0511', 'E0602']
+                                 'W0511', 'E0602', 'C1803', 'C1804', 'C1805',
+                                 'R1737', 'W0719', 'R1734', 'C0201', 'C0411']
 
         # List of files or directories to ignore.
         # Note the limitiation of basenames.

--- a/cog/tasks/pylint.py
+++ b/cog/tasks/pylint.py
@@ -21,7 +21,7 @@ class PyLint(cog.task.Task):
                                  'C0103', 'C0301', 'C0302', 'C0413', 'C0114',
                                  'W0122', 'W0406', 'W0621', 'W0703', 'W0707',
                                  'W0511', 'E0602', 'C1803', 'C1804', 'C1805',
-                                 'R1737', 'W0719', 'R1734', 'C0201', 'C0411']
+                                 'R1737', 'R1734', 'C0201', 'C0411']
 
         # List of files or directories to ignore.
         # Note the limitiation of basenames.

--- a/cog/tasks/pylint.py
+++ b/cog/tasks/pylint.py
@@ -21,7 +21,7 @@ class PyLint(cog.task.Task):
                                  'C0103', 'C0301', 'C0302', 'C0413', 'C0114',
                                  'W0122', 'W0406', 'W0621', 'W0703', 'W0707',
                                  'W0511', 'E0602', 'C1803', 'C1804', 'C1805',
-                                 'R1737', 'R1734', 'C0201', 'C0411']
+                                 'R1734', 'C0201', 'C0411']
 
         # List of files or directories to ignore.
         # Note the limitiation of basenames.


### PR DESCRIPTION
Now that Pylint has been updated for rattests, there are now a number of messages generated by pylint that now cause any test of RAT to fail. This has been described in some detail here: https://github.com/snoplus/rat/issues/3078.

The vast majority of these messages are not indicating actual errors in our Python code, merely suggestions for better practice. As we currently do not have official standards in the Collaboration for Python code within RAT, it seems silly to fail PRs because of these mere suggestions that CIC has not formally approved.

This PR disables almost all of the checks that are currently causing pylint to generate a failure. Once again, see the associated RAT Issue for details on why I believe these should be disabled, and not any others.
This will (sadly) not immediately cause pylint to start passing PRs, as there remain a few actual Python errors we should fix. But by getting this change into cog, we won't be inundated by a wall of irrelevant suggestions.